### PR TITLE
added support to new promises

### DIFF
--- a/xray-reporter.js
+++ b/xray-reporter.js
@@ -61,7 +61,11 @@ const XrayReporter = (options, onPrepareDefer, onCompleteDefer, browser) => {
 
     browser.getProcessedConfig().then((config) => {
         result.info.summary = config.capabilities.name || 'no name';
-        onPrepareDefer.fulfill();
+        if(onPrepareDefer.resolve){
+            onPrepareDefer.resolve();
+        } else {
+            onPrepareDefer.fulfill();
+        }
     });
 
     let specPromises = [];
@@ -188,7 +192,11 @@ const XrayReporter = (options, onPrepareDefer, onCompleteDefer, browser) => {
                 });
             }
             XrayService.createExecution(result, () => {
-                onCompleteDefer.fulfill();
+                if(onCompleteDefer.resolve){
+                    onCompleteDefer.resolve();
+                } else {
+                    onCompleteDefer.fulfill();
+                }
             });
         });
     };


### PR DESCRIPTION
Added support to new promises resolve's method to avoid problems when the new promises arrive.
New promises use "resolve" method not "fulfill"
SeleniumHQ/selenium#2969

_Phase 3: removing the promise manager
Estimated date: October 2018, Node 10.0

On the release of the second major Node LTS with async functions, the ControlFlow class and all related code will be removed. The SELENIUM_PROMISE_MANAGER environment variable will no longer have any effect._